### PR TITLE
Require doctrine/dbal v3.x or v4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^8.0",
         "illuminate/support": "^8.5|^9.0|^10.0|^11.0|^12.0",
-        "doctrine/dbal": "^3.6",
+        "doctrine/dbal": "^3.6|^4.3",
         "nesbot/carbon": "^2.66|^3.8"
     },
     "require-dev": {


### PR DESCRIPTION
Installing the package caused doctrine stuff in my project to be downgraded, so I added 4.x as option.

(No idea what I would be supposed to test now specifically for this.)